### PR TITLE
Fix Nginx config

### DIFF
--- a/server/raffle-client.nginx
+++ b/server/raffle-client.nginx
@@ -15,7 +15,7 @@ server {
     error_log  /var/log/nginx/error_raffler-client.log warn;
 
     location / {
-            try_files $uri $uri/ =404;
+        try_files $uri /index.html;
     }
 }
 


### PR DESCRIPTION
The previous config breaks the `/join` url, this config which was tested on the server just never got put back in here